### PR TITLE
fix: artifact creation

### DIFF
--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -31,7 +31,11 @@ export async function apiDeploy(
         resolved: `Deployment artifact created. (${filepath})\n`,
         rejected: "Deployment artifact creation failed.\n",
       },
-      zip({source: deployFolder, destination: `${testDir}${sep}deploy.zip`}),
+      zip({
+        cwd: deployFolder,
+        source: `.${sep}/*`,
+        destination: filepath,
+      }),
   );
   const uploadLink = createFrom.links.get(
     "https://docs.applura.com/operations/link-relations/upload-frontend-release",

--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -23,12 +23,13 @@ export async function apiDeploy(
   const createFormLink = releaseOverview.links.get("create-form").href;
   const createFrom = await getLinkData(key, createFormLink, { config });
   const testDir = mkdtempSync(`${tmpdir()}${sep}`);
+  const filepath = `${testDir}${sep}deploy.zip`;
   await printWhile(
       stderr,
       {
-        pending: "Creating deploy file…",
-        resolved: "Deploy file creation complete.\n",
-        rejected: "Deploy file creation failed.\n",
+        pending: "Creating deployment artifact…",
+        resolved: `Deployment artifact created. (${filepath})\n`,
+        rejected: "Deployment artifact creation failed.\n",
       },
       zip({source: deployFolder, destination: `${testDir}${sep}deploy.zip`}),
   );


### PR DESCRIPTION
This resolves an issue wherein the deploy directory was included in the zip. I believe this regression was introduced in #2 

Before this PR, the zip content looks like:

```
" zip.vim version v33
" Browsing zipfile /tmp/MfEFpS/deploy.zip
" Select a file with cursor and press ENTER

build/android-chrome-192x192.png
build/android-chrome-512x512.png
build/apple-touch-icon.png
build/favicon-16x16.png
build/favicon-32x32.png
build/favicon.ico
build/img/
build/img/pattern_1.svg
build/index.html
build/index.js
build/index.js.map
build/logo.js
build/logo.js.map
build/logo3.glb
build/main.css
build/manifest.json
build/mstile-150x150.png
build/render.js
build/robots.txt
build/safari-pinned-tab.svg
build/site.webmanifest
```

After this PR, it looks like:

```
" zip.vim version v33
" Browsing zipfile /tmp/rHn5jH/deploy.zip
" Select a file with cursor and press ENTER

android-chrome-192x192.png
android-chrome-512x512.png
apple-touch-icon.png
favicon-16x16.png
favicon-32x32.png
favicon.ico
img/
img/pattern_1.svg
index.html
index.js
index.js.map
logo.js
logo.js.map
logo3.glb
main.css
manifest.json
mstile-150x150.png
render.js
robots.txt
safari-pinned-tab.svg
site.webmanifest
```